### PR TITLE
overview of ML tools that can handle negative event weights

### DIFF
--- a/negative_event_weights/OVERVIEW.md
+++ b/negative_event_weights/OVERVIEW.md
@@ -1,0 +1,42 @@
+# Which ML tools / algorithms / frameworks support negative per-event weights
+
+TODO: link to splot paper
+
+# Toolkits
+
+Toolkits may or may not have per-event weight support on the framework level:
+
+| TMVA                 |    scikit-learn         | Neuro-Bayes        |  Keras    |   ... |
+| -------------------- | ----------------------- | ------------------ | --------- | ----- |
+|        ✓             |                         |                    |           |       |
+
+# Methods
+
+## TMVA
+
+TMVA (possibly due to the HEP background) has per-event weights built-in. Still
+for some MVA methods, they make no sense, are unapplicable. It is therefore
+worth checking on a method-by-method basis
+
+### BDT
+
+#### AdaBoost
+
+AdaBoost by design deals with per-event weights. TMVA combines the boosting
+weights with the per-event weights by multiplying. The only headache is to make
+sure boosting of minus signs boosts "in the right direction".
+
+The actual implementation offers a few options how to deal with negative weights
+
+
+## scikit-learn
+
+My impression is that scikit learn was not designed with per-event weights in
+mind, but that doesn't prevent individual methods to still deal with per-event
+weights.
+
+## Neuro-Bayes
+
+Neuro-Bayes supports sWeights since quite a while and is (to my knowledge) the
+only framework where a general statement "TOOL supports sWeights" is applicable
+*and correct*.

--- a/negative_event_weights/OVERVIEW.md
+++ b/negative_event_weights/OVERVIEW.md
@@ -1,8 +1,8 @@
-# Which ML tools / algorithms / frameworks support negative per-event weights
+#Which ML tools / algorithms / frameworks support negative per - event weights
 
 TODO: link to splot paper
 
-# Toolkits
+#Toolkits
 
 Toolkits may or may not have per-event weight support on the framework level:
 
@@ -10,7 +10,7 @@ Toolkits may or may not have per-event weight support on the framework level:
 | -------------------- | ----------------------- | ------------------ | --------- | ----- |
 |        ✓             |                         |                    |           |       |
 
-# Methods
+#Methods
 
 ## TMVA
 
@@ -18,7 +18,33 @@ TMVA (possibly due to the HEP background) has per-event weights built-in. Still
 for some MVA methods, they make no sense, are unapplicable. It is therefore
 worth checking on a method-by-method basis
 
+Generally for classification tasks, one must provide a signal and a background
+sample. One can not just provide a single tree with positive and negative
+weights to separate the sWeighted component from the rest.
+
+One can however run a classification task of two components within the
+sWeighted fit component.
+
+As example, if one has a data sample of B^0 and anti-B^0 with some background.
+One can perform a fit to determine sWeights and then train a classifier to
+distinguish the B^0 from the anti-B^0, using sWeights to "ignore" the
+background.
+(this is an extremely simplified version of a part of LHCb-PAPER-2018-009)
+
 ### BDT
+
+A couple of negative weight treatments are implemented
+
+`NegWeightTreatment=InverseBoostNegWeights`:
+Does not exist for GradBoost (will be replaced by `Pray`
+
+`NegWeightTreatment=IgnoreNegWeightsInTraining`
+
+`NegWeightTreatment=NoNegWeightsInTraining` (this is a backwards compatibility version of `IgnoreNegWeightsInTraining`
+
+`NegWeightTreatment=PairNegWeightsGlobal`(experimental)
+
+`NegWeightTreatment=Pray`
 
 #### AdaBoost
 


### PR DESCRIPTION
# Which tools and methods work with sWeights

## problem to solve

The sPlot method is a popular tool to statistically disentangle pdfs in mixed
data samples. (From the citations "popular" means 645 citations, judging by eye mostly from BaBar and LHCb. For those unfamiliar with it … I guess "unbinned ABCD method for arbitrary background shapes which
uses Lagrange multipliers to maximise the stat. sensitivity" would be a
one-line summary).

Instead of using a signal sample and a background sample for classification
tasks one wants to train on real data, where there are no 'pure' samples, and
use sWeights to enable the ML training to still maximise the signal/background
discrimination.

Support for per-event weights is crucial for this, and weights can even be
negative. For some ML methods that is almost trivial to support, for some it is
conceptually very hard to figure out what to do with weights. And even if
weights are mathematically straight forward, one wonders "does my software
support per-event weights?". This is a reoccuring question (in LHCb at least)
and there appears to be no universal and complete list of ML methods that work
well with sWeights (to be fair, that is a moving target as new tools come out
and support is improved).

I want assemble a list of ML methods which states their support for negative
per event weights. (e.g. for TMVA's BDTs we will list the options to
enable/adjust their treatment).

## desired outcome

**A human readable list, which one can refer to in an FAQ**

Further details can be discussed (include notebook to run and try, quantitative
comparison, restrict to "implemented in principle" or also state discrimination
power, best way of hosting - like a community driven github awesome list, or
wiki).

## looking for know-how

I guess I'm most familiar with TMVA, if there are users of other popular tools
who like to join, that would help.

## preparation

I have a dataset in mind to test.

If someone has a … notebook(?) … where we can test scikit-learn or keras
already, that might speed our startup up.  Is there:

## further reading, anything else

Helpful links! I have to add them!
