### PR TITLE
compare uBoost to "learning to pivot"

### DIFF
--- a/uBoost_pivot/README.md
+++ b/uBoost_pivot/README.md
@@ -1,0 +1,12 @@
+# outline
+
+When discussing "Learning to Pivot with Adversarial Networks," arXiv:1611.01046
+in the IML meeting, it came up that the goal is not too different from "uBoost:
+A boosting method for producing uniform selection efficiencies from
+multivariate classifiers," arXiv:1305.7248 [nucl-ex] or "New approaches for
+boosting to uniformity," arXiv:1410.4140 [hep-ex].
+
+Yet there seem to be no direct (or well known) comparisons of the methods. We
+discussed some theoretical differences / similarities / advantages /
+applicabilities in the meeting back then, but it would be nice to just run a
+comparison and learn from it.


### PR DESCRIPTION
# title: compare uBoost to "learn to pivot"

**DISCLAIMER** I already work on a different project, but I would be happy if someone picks this idea up!

## problem to solve

When discussing "Learning to Pivot with Adversarial Networks," arXiv:1611.01046
in the IML meeting, it came up that the goal is not too different from "uBoost:
A boosting method for producing uniform selection efficiencies from
multivariate classifiers," arXiv:1305.7248 [nucl-ex] or "New approaches for
boosting to uniformity," arXiv:1410.4140 [hep-ex].

Yet there seem to be no direct (or well known) comparisons of the methods. We
discussed some theoretical differences / similarities / advantages /
applicabilities in the meeting back then, but it would be nice to just run a
comparison and learn from it.
Give us some background. What are you wondering about? What unsolved question
do you want to shed light on? Which bug are you trying to fix / missing feature
to provide?

## desired outcome

Having a like-with-like comparison of the methods.

Ideally a notebook (maybe from the learn-to-pivot examples) where a uBoost and
a pivoting classifier are trained and compared.

## looking for know-how

Minimal python or sklearn knowledge would help (to be able to run the uBoost
classifiers from the `hep_ml` python package).

## preparation

none. Or searching for existing tutorials of either tool, maybe searching for
data to run on.

## further reading, anything else

The three arxiv papers above and the documentation of hep_ml.

arXiv:1611.01046
arXiv:1305.7248
arXiv:1410.4140

https://arogozhnikov.github.io/hep_ml/
