### PR TITLE
figure of merit project

### DIFF
--- a/FoM/README.md
+++ b/FoM/README.md
@@ -1,0 +1,21 @@
+# figures of merit
+
+One popular figure of merit in searches is the ``Punzi figure of merit''
+(Sensitivity of searches for new signals and its optimization https://arxiv.org/abs/physics/0308063).
+
+Its appeal is that it does not require the input of an expected signal strength
+/ cross section to compute (other than a signal-to-background ratio or signal
+purity) and does not vanish if the expected signal yield is zero.
+
+(One should compare this to Andrea's talk at the workshop on figures of merit,
+if there is something else of interest / better)
+
+Yet, it may not be implemented in ML toolkits for quick and easy evaluation (or
+even hyper parameter optimization and model selection). So it would be nice to
+write a small python module to work with the scikit-learn interfaces and create
+a pull request to the `hep_ml` package, and/or a small extension to the TMVA
+Gui.
+
+Alternatively, if such implementations already exist, we might want to
+advertise them (start with a pull request to popular packages directly, make
+the paper-software link findable on the HEP-ML-resources list …).


### PR DESCRIPTION
# figures of merit implementations

**DISCLAIMER** again, just an idea for projects (the outcome of which I'm looking forward to use in the future). Won't work on it myself at the hackathon

One popular figure of merit in searches is the ``Punzi figure of merit''
(Sensitivity of searches for new signals and its optimization https://arxiv.org/abs/physics/0308063).

Its appeal is that it does not require the input of an expected signal strength
/ cross section to compute (other than a signal-to-background ratio or signal
purity) and does not vanish if the expected signal yield is zero.

(One should compare this to Andrea's talk at the workshop on figures of merit,
if there is something else of interest / better)

## problem to solve

Yet, it may not be implemented in ML toolkits for quick and easy evaluation (or
even hyper parameter optimization and model selection). So it would be nice to
write a small python module to work with the scikit-learn interfaces and create
a pull request to the `hep_ml` package, and/or a small extension to the TMVA
Gui.

Alternatively, if such implementations already exist, we might want to
advertise them (start with a pull request to popular packages directly, make
the paper-software link findable on the HEP-ML-resources list …).

## desired outcome

Have ``better'' or corner case figures of merit implemented in popular toolkits,
possibly document how the existing ones are commonly accidentially misused.

## looking for know-how

No real prerequists.

Knowing your way around the backends of TMVA Gui, TMVA cross validation,
scikit-learn optimisers, scikit-optimize, hep_ml will help, but they all should
be easy enough to dive in quickly.

## preparation

Listen to Andrea's talk

Familiarize yourself with the issues of figures of merit.

(i.e. what's computable on an event-by-event basis as loss function, what only
makes sense on a test sample. What ``external'' inputs (e.g. absolute backround
level) are needed?)
